### PR TITLE
Fix callback crash, solves #1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,6 +15,7 @@ The name of the game is mostly to identify Chipmunk objects, create a safe wrapp
 - [ ] Implement remaining body components
 - [ ] Implement remaining global properties
 - [ ] Implement remaining constraints
+- [ ] Free FunPtrs
 - [ ] Add explicitly managed shapes whose properties you can change at runtime
 - [ ] Include entity index from data pointer in Chipmunk error messages
 - [ ] Check(enforce?) proper deallocation of bodies/shapes/constraints on overwrites etc.

--- a/src/Apecs/Physics/Collision.hs
+++ b/src/Apecs/Physics/Collision.hs
@@ -34,33 +34,30 @@ C.context (phycsCtx `mappend` C.funCtx)
 C.include "<chipmunk.h>"
 C.include "<chipmunk_structs.h>"
 
--- | Necessary to pass the @w@ argument, but I'm interested in a way to remove this
-makeCallback :: (CollisionPair -> System w a) -> System w (Callback a)
+makeCallback :: (CollisionPair -> System w Bool) -> System w BeginCB
 makeCallback sys = do
     w <- System ask
-    return . Callback $ \pair -> runSystem (sys pair) w
+
+    let cb arb _ _ = do
+          nx <- realToFrac   <$> [C.exp| double { cpArbiterGetNormal($(cpArbiter* arb)).x } |]
+          ny <- realToFrac   <$> [C.exp| double { cpArbiterGetNormal($(cpArbiter* arb)).y } |]
+          ea <- fromIntegral <$> [C.block| unsigned int { CP_ARBITER_GET_BODIES($(cpArbiter* arb), ba, bb); return (intptr_t) (ba->userData); } |]
+          eb <- fromIntegral <$> [C.block| unsigned int { CP_ARBITER_GET_BODIES($(cpArbiter* arb), ba, bb); return (intptr_t) (bb->userData); } |]
+          r <- liftIO$ runSystem (sys (CollisionPair (V2 nx ny) (Entity ea) (Entity eb))) w
+          return . fromIntegral . fromEnum $ r
+
+    a <- liftIO$ $(C.mkFunPtr [t| Ptr CollisionPair -> Ptr FrnSpace -> C.CUInt -> IO C.CUChar |]) cb
+    return (BeginCB a)
 
 newCollisionHandler :: SpacePtr -> CollisionHandler -> Int -> IO (Ptr CollisionHandler)
 newCollisionHandler spcPtr (CollisionHandler cta ctb begin separate) (fromIntegral -> ety) =
   withForeignPtr spcPtr $ \space -> do
     handler <- [C.exp| cpCollisionHandler* {cpSpaceAddCollisionHandler($(cpSpace* space), $(unsigned int cta), $(unsigned int ctb))}|]
-
-    forM_ begin $ \(Callback cb) ->
-      let sys_ arb spc _ = do nx <- realToFrac <$> [C.exp| double { cpArbiterGetNormal($(cpArbiter* arb)).x } |]
-                              ny <- realToFrac <$> [C.exp| double { cpArbiterGetNormal($(cpArbiter* arb)).y } |]
-                              ea <- fromIntegral <$> [C.block| unsigned int { CP_ARBITER_GET_BODIES($(cpArbiter* arb), ba, bb); return (intptr_t) (ba->userData); } |]
-                              eb <- fromIntegral <$> [C.block| unsigned int { CP_ARBITER_GET_BODIES($(cpArbiter* arb), ba, bb); return (intptr_t) (bb->userData); } |]
-                              fromIntegral . fromEnum <$> cb (CollisionPair (V2 nx ny) (Entity ea) (Entity eb))
-
-        -- FIXME:
-        -- It seems like this callback is never called.
-        -- The default beginFunc is properly called if we don't change this value, and we get an error on collision if we set it to NULL,
-        -- so it _is_ used at runtime...
-       in [C.block| void { $(cpCollisionHandler* handler)->beginFunc = $fun:(unsigned char (*sys_)(cpArbiter*,cpSpace*,cpDataPointer));
-                           $(cpCollisionHandler* handler)->userData = (void*) $(intptr_t ety);
-                         }|]
-
-    forM_ separate $ \e -> putStrLn "Separation callbacks not yet implemented"
+    forM_ begin$ \(BeginCB cb) -> do
+      let fn = $(C.peekFunPtr [t| BeginFunc |]) cb
+      [C.block| void {
+      $(cpCollisionHandler* handler)->beginFunc = $fun:(unsigned char (*fn)(cpArbiter*, cpSpace*, cpDataPointer));
+      $(cpCollisionHandler* handler)->userData = (void*) $(intptr_t ety); }|]
 
     return handler
 

--- a/src/Apecs/Physics/Types.hs
+++ b/src/Apecs/Physics/Types.hs
@@ -170,12 +170,11 @@ data ConstraintType
 newtype SeparateCB = SeparateCB (FunPtr (Ptr CollisionPair -> Ptr FrnSpace -> C.CUInt -> IO ()))
 
 type BeginFunc = Ptr CollisionPair -> Ptr FrnSpace -> C.CUInt -> IO C.CUChar
-newtype BeginCB = BeginCB (FunPtr BeginFunc)
 
 data CollisionHandler = CollisionHandler
   { handlerA        :: CollisionType
   , handlerB        :: CollisionType
-  , handlerBegin    :: Maybe BeginCB
+  , handlerBegin    :: Maybe BeginFunc
   , handlerSeparate :: Maybe SeparateCB
   }
 

--- a/src/Apecs/Physics/Types.hs
+++ b/src/Apecs/Physics/Types.hs
@@ -167,13 +167,16 @@ data ConstraintType
 -- getPinJointDistance
 -- getSlideJointDistance?
 
-newtype Callback a     = Callback (CollisionPair -> IO a)
+newtype SeparateCB = SeparateCB (FunPtr (Ptr CollisionPair -> Ptr FrnSpace -> C.CUInt -> IO ()))
+
+type BeginFunc = Ptr CollisionPair -> Ptr FrnSpace -> C.CUInt -> IO C.CUChar
+newtype BeginCB = BeginCB (FunPtr BeginFunc)
 
 data CollisionHandler = CollisionHandler
   { handlerA        :: CollisionType
   , handlerB        :: CollisionType
-  , handlerBegin    :: Maybe (Callback Bool)
-  , handlerSeparate :: Maybe (Callback ())
+  , handlerBegin    :: Maybe BeginCB
+  , handlerSeparate :: Maybe SeparateCB
   }
 
 data CollisionPair = CollisionPair


### PR DESCRIPTION
Creating a `FunPtr` was the right idea, but `peekFunPtr` turns it back into a regular Haskell function, so calling that regular function from C is just as problematic as before. Instead, use `castFunPtrToPtr` to obtain the corresponding raw pointer.

Note that neither this version nor the buggy version is calling `freeHaskellFunPtr` anywhere, so this leaks memory.