### PR TITLE
Compatibility with apecs-0.5.1.0 + small fixes

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,40 @@
+{-# LANGUAGE CPP #-}
 import Distribution.Simple
-main = defaultMain
+import Distribution.PackageDescription
+
+
+main = defaultMainWithHooks simpleUserHooks
+    { readDesc = (fmap . fmap) addCFilesIfNeeded (readDesc simpleUserHooks)
+    }
+  where
+    addCFilesIfNeeded genPkgDescr =
+#if MIN_VERSION_inline_c(0, 6, 0)
+      genPkgDescr
+#else
+      addCFiles genPkgDescr
+#endif
+
+    addCFiles genPkgDescr = genPkgDescr
+      { packageDescription = newPkgDescription
+      }
+      where
+        pkgDescr = packageDescription genPkgDescr
+        pkgLibrary = library pkgDescr
+        newPkgDescription = pkgDescr
+          { library = fmap addCFiles' pkgLibrary
+          }
+        addCFiles' lib = lib
+          { libBuildInfo =
+              let buildInfo = libBuildInfo lib in
+                buildInfo
+                { cSources = cSources buildInfo ++
+                    [ "src/Apecs/Physics/Constraint.c"
+                    , "src/Apecs/Physics/Space.c"
+                    , "src/Apecs/Physics/Query.c"
+                    , "src/Apecs/Physics/Body.c"
+                    , "src/Apecs/Physics/Collision.c"
+                    , "src/Apecs/Physics/Shape.c"
+                    ]
+                }
+          }
+

--- a/Setup.hs
+++ b/Setup.hs
@@ -3,20 +3,21 @@ import Distribution.Simple
 import Distribution.Verbosity
 import Distribution.PackageDescription
 import Distribution.PackageDescription.Parse
-import Debug.Trace (trace)
 
 
 main = do
-    pkgDescr <- readPackageDescription verbose "apecs-physics.cabal"
-    let newPkgDescr = addCFilesIfNeeded pkgDescr
-    print newPkgDescr
-    defaultMainNoRead newPkgDescr
-  where
-    addCFilesIfNeeded genPkgDescr =
-#if __GLASGOW_HASKELL__ >= 802
-      genPkgDescr
+#if defined(MIN_VERSION_Cabal) && MIN_VERSION_Cabal(2,0,0)
+    pkgDescr <- readGenericPackageDescription verbose "apecs-physics.cabal"
 #else
-      addCFiles genPkgDescr
+    pkgDescr <- readPackageDescription verbose "apecs-physics.cabal"
+#endif
+    defaultMainNoRead . addCFilesIfNeeded $ pkgDescr
+  where
+    addCFilesIfNeeded =
+#if __GLASGOW_HASKELL__ >= 802
+      id
+#else
+      addCFiles
 #endif
 
     addCFiles genPkgDescr = genPkgDescr

--- a/apecs-physics-gloss/apecs-physics-gloss.cabal
+++ b/apecs-physics-gloss/apecs-physics-gloss.cabal
@@ -1,7 +1,7 @@
 name:                apecs-physics-gloss
 version:             0.1.0.0
--- synopsis:
--- description:
+synopsis:            Gloss rendering for apecs-physics
+description:         Gloss rendering for apecs-physics
 homepage:            https://github.com/jonascarpay/apecs-physics#readme
 license:             BSD3
 author:              Jonas Carpay

--- a/apecs-physics.cabal
+++ b/apecs-physics.cabal
@@ -13,6 +13,11 @@ build-type:          Custom
 cabal-version:       >=1.10
 extra-source-files:  README.md
 
+custom-setup
+  setup-depends:
+    base  >= 4.5 && < 4.11,
+    Cabal >= 1.14
+
 flag release
   description: Release mode, better performance but no longer provides debug info on the command line.
   Manual:  True

--- a/apecs-physics.cabal
+++ b/apecs-physics.cabal
@@ -9,7 +9,7 @@ author:              Jonas Carpay
 maintainer:          jonascarpay@gmail.com
 copyright:           MIT
 category:            Web
-build-type:          Simple
+build-type:          Custom
 cabal-version:       >=1.10
 extra-source-files:  README.md
 
@@ -55,7 +55,6 @@ library
   include-dirs:
     Chipmunk2D/include/chipmunk
   c-sources:
-
     Chipmunk2D/src/chipmunk.c
     Chipmunk2D/src/cpBody.c
     Chipmunk2D/src/cpArbiter.c

--- a/examples/Constraints.hs
+++ b/examples/Constraints.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeFamilies          #-}

--- a/examples/HelloWorld.hs
+++ b/examples/HelloWorld.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell       #-}
 

--- a/examples/Tumbler.hs
+++ b/examples/Tumbler.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TemplateHaskell       #-}
 {-# LANGUAGE TypeFamilies          #-}

--- a/src/Apecs/Physics/Space.hs
+++ b/src/Apecs/Physics/Space.hs
@@ -47,7 +47,7 @@ instance Component Physics where
 
 type instance Elem (Space Physics) = Physics
 
-instance ExplInit (Space Physics) where
+instance ExplInit IO (Space Physics) where
   explInit = do
     spacePtr <- newSpace
     bRef     <- newIORef mempty

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,11 @@
-resolver: lts-9.11
+resolver: lts-10.10
 packages:
 - .
 - apecs-physics-gloss
 - examples
 extra-deps:
-  - apecs-0.3.0.2
+  - apecs-0.5.1.0
 flags: {}
 extra-package-dbs: []
+nix:
+  packages: [libGL mesa_glu freeglut]


### PR DESCRIPTION
This commit:
- Bumps apecs to 0.5.1.0 in `stack.yaml`.
- Fixes ensuing compiler errors.
- Bumps Stackage LTS to 10.10 (GHC 8.2.2).
- Fixes linker errors on NixOS.

See #5 for some context.